### PR TITLE
bumped dl version. Add VNA autoscale to data cadence

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-from driplineorg/dripline-python:v4.4.5-amd64
+from driplineorg/dripline-python:v4.4.6-amd64
 
 COPY . /usr/local/src/dripline-python-plugin
 

--- a/data_taking_scripts/common_functions.py
+++ b/data_taking_scripts/common_functions.py
@@ -49,11 +49,22 @@ def data_logging_sequence(a_sec_wait_for_na_averaging):
     the_interface.set('na_measurement_status', 'start_measurement')
     print('Logging list of endpoints')
     the_interface.cmd('modemap_snapshot_no_iq', 'log_entities')
+
+    # switch the na to read s21
     the_interface.get('na_s21_iq_data')
+    #  autoscale the window so that the s21 data fits. This is so I can watch the data while it's being recorded.
+    the_interface.set('na_commands', 'autoscale')
+    #wait for network analyzer to finish several sweeps for averaging
     time.sleep(a_sec_wait_for_na_averaging)
+    # then record s21 data into database
     the_interface.cmd('na_s21_iq_data', 'scheduled_log')
+    # switch the na to read s11
     the_interface.get('na_s11_iq_data')
+    #  autoscale the window so that the s11 data fits. This is so I can watch the data while it's being recorded.
+    the_interface.set('na_commands', 'autoscale')
+    #wait for network analyzer to finish several sweeps for averaging
     time.sleep(a_sec_wait_for_na_averaging)
+    # then record s11 data into database
     the_interface.cmd('na_s11_iq_data', 'scheduled_log')
     print('Setting na_measurement_status to stop_measurement')
     the_interface.set('na_measurement_status', 'stop_measurement')

--- a/data_taking_scripts/dripline_logger.py
+++ b/data_taking_scripts/dripline_logger.py
@@ -6,16 +6,24 @@ class DriplineLogger:
         self.auths_file = auths_file
         self.cmd_interface = Interface(dripline_config={'auth-file': self.auths_file})
 
-    def log_modemap(self, sleep_time):
+    def log_modemap(self, sec_wait_for_na_averaging):
         print('Setting na_measurement_status to start_measurement')
         self.cmd_interface.set('na_measurement_status', 'start_measurement')
         print('Logging list of endpoints')
         self.cmd_interface.cmd('modemap_snapshot_no_iq', 'log_entities')
+
         self.cmd_interface.get('na_s21_iq_data')
-        time.sleep(sleep_time)
+	#  autoscale the window so that the s21 data fits. This is so I can watch the data while it's being recorded.
+	self.cmd_interface.set('na_commands', 'autoscale')
+	#  wait for network analyzer to finish several sweeps for averaging
+        time.sleep(sec_wait_for_na_averaging)
         self.cmd_interface.cmd('na_s21_iq_data', 'scheduled_log')
+
         self.cmd_interface.get('na_s11_iq_data')
-        time.sleep(sleep_time)
+	#  autoscale the window so that the s11 data fits. This is so I can watch the data while it's being recorded.
+	self.cmd_interface.set('na_commands', 'autoscale')
+	#  wait for network analyzer to finish several sweeps for averaging
+        time.sleep(sec_wait_for_na_averaging)
         self.cmd_interface.cmd('na_s11_iq_data', 'scheduled_log')
         print('Setting na_measurement_status to stop_measurement')
         self.cmd_interface.set('na_measurement_status', 'stop_measurement')
@@ -26,4 +34,3 @@ class DriplineLogger:
     def stop_modemap(self):
         self.cmd_interface.set('modemap_measurement_status', 'stop_measurement')
 
-    


### PR DESCRIPTION
Initially, when we take a modemap, s11 wouldn't be visible on the VNA screen. That's because the screen is scaled to fit s21 data, and s11 is larger than s21 by several orders of magnitude. So I can't visually keep track of the reflection measurement while s11 data is being collected.

I made the data cadence autoscale the VNA whenever it switches from s11 and s21. That way, I can always see the data while the measurement is happening. I hope that this helps me understand the experiment better while it's measuring a modemap.

I also upgraded the dripline version. 