### PR TITLE
Feature/force modemap notes

### DIFF
--- a/data_taking_scripts/motor_control.py
+++ b/data_taking_scripts/motor_control.py
@@ -25,6 +25,9 @@ num_plates = 4
 orpheus_motors = OrpheusMotors(auths_file, motors_to_move)
 logger = DataLogger(auths_file)
 
+#  Ask user to describe the measurement. Forces user to document what they are doing. 
+measurement_description = input('Describe the current measurement setup: ')
+
 logger.initialize_na_settings_for_modemap(averages = 16)
 orpheus_motors.move_to_zero()
 orpheus_motors.wait_for_motors()
@@ -33,7 +36,7 @@ initial_plate_separation = orpheus_motors.plate_separation(mirror_spacing_tracke
 
 #Send alert saying you are starting the modemap measurement
 print('Starting modemap measurement')
-logger.start_modemap('Debugging dielectrics setup')
+logger.start_modemap(measurement_description)
 
 current_resonator_length = inch_to_cm(initial_mirror_holder_spacing)+1.0497
 wide_scan_start_freq = 15e9


### PR DESCRIPTION
motor_control.py will ask the user to add notes about the current measurement. Those notes will be logged under the modemap_measurement_status_explanation. The point of those notes is to add documentation of the measurement into the database, such as "empty resonator in liquid nitrogen."